### PR TITLE
Stamp bootstrap provenance markers on workflow files

### DIFF
--- a/.github/workflows/codeql-noop.yml
+++ b/.github/workflows/codeql-noop.yml
@@ -1,3 +1,5 @@
+# claude-bootstrap: rendered from public/.github/workflows/codeql-noop.yml.tmpl @ v1.48.2 sha256:3074535e1feadb97919a0e83980c85714c9dbd5899e14e2911937b2b5b6910a4
+# (do not edit this line; the maintenance pipeline uses it for drift detection — see #213)
 # Doc-only PR companion for codeql.yml — see quality-public-noop.yml's
 # header for the rationale and mixed-PR caveat. Mirrors the matrix shape
 # of the main analyze job so each `analyze (<lang>)` required-status

--- a/.github/workflows/quality-public-noop.yml
+++ b/.github/workflows/quality-public-noop.yml
@@ -1,3 +1,5 @@
+# claude-bootstrap: rendered from public/.github/workflows/quality-public-noop.yml.tmpl @ v1.48.2 sha256:306ef7ad05d535f13d66b4d3d71f240329dbccd58543c954bbb22664c5728d42
+# (do not edit this line; the maintenance pipeline uses it for drift detection — see #213)
 # Doc-only PR companion for quality-public.yml.
 #
 # Why this file exists: required status checks resolve by NAME, and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# claude-bootstrap: rendered from languages/java/.github/workflows/release.yml.tmpl @ v1.48.2 sha256:0f959722c0cd8c3afbc8d38585bfa25fa0bcf5bd33e5f56c704e2cf11059787e
+# (do not edit this line; the maintenance pipeline uses it for drift detection — see #213)
 # Release workflow — build-driven semantic versioning via nebula-release.
 #
 # The project version is DERIVED from git tags by the nebula.release Gradle
@@ -30,8 +32,8 @@ on:
         options: ["auto", "patch", "minor", "major"]
         default: "auto"
 
-# Least-privilege default; the release job widens to contents: write below
-# (nebula's `final` task pushes the release tag).
+# Least-privilege default at workflow scope; the release job widens to
+# contents: write below (nebula's `final` task pushes the release tag).
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Re-running `/development:bootstrap` (State D gap-fill) found the repo fully bootstrapped with no GitHub-side gaps. The only outstanding item: three workflows predated the provenance-marker mechanism (#213) and reported as `unknown_provenance` on every maintenance run.

This adds the `claude-bootstrap` provenance marker (template path, plugin version, template sha256) to:

- `.github/workflows/codeql-noop.yml`
- `.github/workflows/quality-public-noop.yml`
- `.github/workflows/release.yml`

The maintenance drift detector reads these markers to track upstream template drift. After this change the detector reports clean (`[]`).

Also reflows `release.yml`'s least-privilege permissions comment to match the current template (cosmetic, no behavior change).

## Notes

- All three files were verified byte-identical to the current templates before stamping (release.yml differed only by the comment wording, now synced).
- No functional / Java code changes — diff is workflow-comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)