### PR TITLE
Fix duplicate-class build failure from mis-pathed proto source set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,14 +57,11 @@ protobuf {
     }
 }
 
-sourceSets {
-    main {
-        java {
-            srcDirs("build/generated/source/proto/main/grpc")
-            srcDirs("build/generated/source/proto/main/java")
-        }
-    }
-}
+// NOTE: do NOT manually add the protobuf output dirs to the `main` source set.
+// The com.google.protobuf plugin already registers its real output
+// (build/generated/sources/proto/...) with the source set automatically. A
+// manual srcDirs entry pointing at a stale/parallel path (e.g. the singular
+// "source" dir) causes the same stubs to be compiled twice -> "duplicate class".
 
 testing {
     suites {


### PR DESCRIPTION
## Problem

Incremental Gradle builds intermittently failed with `duplicate class: snapper.Ticker…` (and the other proto/gRPC stubs), forcing a `./gradlew clean` to recover.

## Root cause

The `com.google.protobuf` plugin (0.9.6) generates stubs into **`build/generated/sources/proto/...`** (plural `sources`) and — since plugin 0.8 — **automatically registers that directory with the `main` source set**.

`build.gradle.kts` *also* manually registered a **different, wrong path**: **`build/generated/source/proto/...`** (singular `source`), which the plugin never writes to.

- In a clean build that manual `srcDirs` entry is dead — it points at a directory that doesn't exist.
- But whenever the singular path gets populated (stale output from an older plugin version, an IDE, or a `build/` dir carried across sessions), Gradle compiles those stale stubs **alongside** the plugin's fresh stubs → duplicate class.

The Sonar / JaCoCo / Spotless exclusions were already correct (`**/build/generated/**` matches the real plural path), so generated sources were already excluded from analysis and coverage — this was purely a source-set wiring bug.

## Fix

Remove the redundant, mis-pathed manual `sourceSets` block and rely on the plugin's automatic registration of the correct output path. Replaced with an explanatory comment so it isn't re-added.

## Verification

- `./gradlew clean test jacocoTestReport` — succeeds; stubs compile via the plugin's auto-registration.
- Planted a stale file under the singular `source` path (the exact scenario that broke the build) and ran an incremental `compileJava` — **no duplicate class** anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)