### PR TITLE
fix(approver): adopt #411 EXPECTED_CHECKS gate + bump plugins ref

### DIFF
--- a/.github/workflows/claude-approver.yml
+++ b/.github/workflows/claude-approver.yml
@@ -1,4 +1,4 @@
-# claude-bootstrap: rendered from common/.github/workflows/claude-approver.yml.tmpl @ v1.53.0 sha256:30852188bfa71c1c0947e35a55dbb0097008c545c20d57641083e8deb38e4129
+# claude-bootstrap: rendered from common/.github/workflows/claude-approver.yml.tmpl @ v1.53.11 sha256:ef1f9bb44f0244ec190f3adbd04b3e194c688c5865ed8f50d03661449c870a5f
 # (do not edit this line; the maintenance pipeline uses it for drift detection — see #213)
 # Claude Approver — the final synthesis layer for PR approval.
 #
@@ -271,6 +271,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
+          # The required status-check contexts branch protection enforces
+          # (#411) — rendered by the bootstrap to match the `checks=(...)` set
+          # in scripts/branch-protection.sh. The wait loop below blocks until
+          # every one of these has *registered and settled*, so the gate can
+          # never judge a half-built check set. Without it, a run that fires
+          # before the long-pole jobs (test-and-coverage, sonarcloud) have even
+          # created their check runs sees zero-pending and evaluates against
+          # nothing. An empty array `[]` degrades safely to the pre-#411
+          # behaviour (wait only for whatever has already registered).
+          EXPECTED_CHECKS: '["test-and-coverage","semgrep","pre-commit","sonarcloud","license-fs","analyze (java)"]'
         run: |
           set -e
           # `-R "$REPO"` is needed because no checkout has run yet — see #203.
@@ -293,30 +303,56 @@ jobs:
                          | select(.name != "approve" and .name != "approver-gate")
                          | {name: .name, status: .status, conclusion: .conclusion}' \
                    | jq -s .)
-            # Legacy commit-status API (third-party check posters). The
-            # combined state reads 'pending' when zero statuses exist, so
-            # only treat it as in-flight when there are actual statuses.
-            status=$(gh api "repos/$REPO/commits/$head_sha/status" \
-                     --jq '{state: .state, total: .total_count}')
-            status_state=$(printf '%s' "$status" | jq -r .state)
-            status_total=$(printf '%s' "$status" | jq -r .total)
+            # Legacy commit-status API (third-party check posters). Fetched in
+            # full once per poll and reused below for both the in-flight test
+            # and the expected-set test (#411). The combined state reads
+            # 'pending' when zero statuses exist, so only treat it as in-flight
+            # when there are actual statuses.
+            status_full=$(gh api "repos/$REPO/commits/$head_sha/status")
+            status_state=$(printf '%s' "$status_full" | jq -r .state)
+            status_total=$(printf '%s' "$status_full" | jq -r .total_count)
 
             pending=$(printf '%s' "$runs" | jq 'map(select(.status != "completed")) | length')
-            if [ "$pending" -eq 0 ] && { [ "$status_total" -eq 0 ] || [ "$status_state" != "pending" ]; }; then
+
+            # #411: never judge a partial check set. `pending` only counts
+            # checks that have ALREADY registered — a long-pole job whose check
+            # run doesn't exist yet reads as zero-pending, which is what let an
+            # early run break out and post a verdict before test-and-coverage /
+            # sonarcloud even started. So additionally require every EXPECTED
+            # context (the branch-protection required set) to have registered
+            # and reached a terminal state. Match expected names against both
+            # check-run names and legacy commit-status contexts, since branch
+            # protection gates on either. Empty EXPECTED_CHECKS → no expected
+            # gate (pre-#411 behaviour).
+            settled_names=$(jq -n \
+              --argjson runs "$runs" \
+              --argjson status "$status_full" \
+              '[ $runs[] | select(.status == "completed") | .name ]
+               + [ $status.statuses[] | select(.state != "pending") | .context ]
+               | unique')
+            missing=$(jq -n --argjson exp "$EXPECTED_CHECKS" --argjson settled "$settled_names" \
+                      '$exp - $settled')
+            missing_n=$(printf '%s' "$missing" | jq 'length')
+
+            if [ "$missing_n" -eq 0 ] && [ "$pending" -eq 0 ] \
+               && { [ "$status_total" -eq 0 ] || [ "$status_state" != "pending" ]; }; then
               break
             fi
 
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::notice::Still waiting on $pending check(s) (combined status: $status_state)" \
-                "after 30 minutes — giving up; the next trigger re-evaluates."
+              echo "::notice::Still waiting after 30 minutes — giving up; the" \
+                "next trigger re-evaluates. pending=$pending, combined" \
+                "status=$status_state, expected checks not yet settled:" \
+                "$(printf '%s' "$missing" | jq -c .)"
               exit 0
             fi
 
             # If a push lands while we wait, the `synchronize` trigger
             # cancels this run via the concurrency group — no need to
             # re-resolve the head SHA inside the loop.
-            echo "Waiting: $pending check(s) in progress, combined status '$status_state'" \
-              "($status_total status(es)) on $head_sha."
+            echo "Waiting: $pending check(s) in progress, combined status" \
+              "'$status_state' ($status_total status(es)), $missing_n expected" \
+              "check(s) not yet settled on $head_sha."
             sleep 30
           done
 
@@ -346,7 +382,8 @@ jobs:
           # Required legacy statuses (e.g. `sonarcloud`) are NOT excluded and
           # still gate as before.
           if [ "$status_total" -gt 0 ]; then
-            status_full=$(gh api "repos/$REPO/commits/$head_sha/status")
+            # Reuse the combined-status payload from the final wait iteration
+            # (all statuses are settled by the time we break out, #411).
             advisory='select(.context != "code/snyk" and (.context | startswith("security/snyk") | not))'
             bad_status=$(printf '%s' "$status_full" \
                          | jq "[.statuses[] | $advisory | select(.state != \"success\")] | length")
@@ -417,14 +454,14 @@ jobs:
       # ============================================================
       # Pull in the Claude plugin family so the java-approver
       # agent is loadable. The bootstrap renders the repo + ref from
-      # timo-jakob/timos-claude-code-plugins / f34c8b5420fc3b4658bc36b5cbcc39ff1c7c30c0; defaults pin
+      # timo-jakob/timos-claude-code-plugins / eca2b9ad513c916f2a16f89df619def058efce8b; defaults pin
       # the canonical fork.
       # ============================================================
       - name: Checkout Claude plugin family
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: "timo-jakob/timos-claude-code-plugins"
-          ref: "f34c8b5420fc3b4658bc36b5cbcc39ff1c7c30c0"
+          ref: "eca2b9ad513c916f2a16f89df619def058efce8b"
           path: .claude-plugins
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Reconciles `.github/workflows/claude-approver.yml` with the current (v1.53.11) bootstrap template — surfaced as template drift by a `/development:bootstrap` re-run.

The all-green gate now waits until **every branch-protection-required check** has *registered and settled* before judging (#411), so it can no longer approve against a half-built check set. Previously a run firing before the long-pole jobs (`test-and-coverage`, `sonarcloud`) created their check-runs would see zero-pending and evaluate against nothing.

## Changes

- Add `EXPECTED_CHECKS` env + `settled_names`/`missing` wait logic to Gate 5 — block until all required contexts settle.
- Fold the legacy commit-status fetch into a single `status_full` call reused across the wait loop and advisory-status block.
- Bump the loaded plugins ref `f34c8b5` → `eca2b9a`.
- Restamp the provenance marker to v1.53.11.

## Preserved (local hardening, not regressed)

- SHA-pinned actions (`checkout@…v7`, `create-github-app-token@…v3`).
- Per-job least-privilege `permissions:` blocks + workflow-level `permissions: {}`.
- `# NOSONAR` justification comments.

## Type

Fix (CI workflow hardening — no application code touched).

## Risk

Low. Workflow-only change; drift detector now returns clean, YAML validates, bash variables consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)